### PR TITLE
Add tests for AuthService

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -29,6 +30,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/__tests__/authService.test.ts
+++ b/src/__tests__/authService.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AuthService } from '../services/authService';
+
+// Helper to reset localStorage before each test
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('AuthService', () => {
+  it('signUp registers and logs in a new user', async () => {
+    const service = new AuthService();
+    const result = await service.signUp('test@example.com', 'Test User', '123456');
+
+    expect(result.success).toBe(true);
+    expect(result.user).toBeTruthy();
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.getCurrentUser()?.email).toBe('test@example.com');
+  });
+
+  it('signUp prevents duplicate email', async () => {
+    const service = new AuthService();
+    await service.signUp('dup@example.com', 'Dup', '123456');
+    const result = await service.signUp('dup@example.com', 'Dup2', '123456');
+
+    expect(result.success).toBe(false);
+    expect(service.getUsersCount()).toBe(1);
+  });
+
+  it('signIn authenticates an existing user', async () => {
+    const service = new AuthService();
+    await service.signUp('login@example.com', 'Login', '123456');
+    service.signOut();
+    const result = await service.signIn('login@example.com', '123456');
+
+    expect(result.success).toBe(true);
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.getCurrentUser()?.email).toBe('login@example.com');
+  });
+
+  it('signIn fails for unknown user', async () => {
+    const service = new AuthService();
+    const result = await service.signIn('missing@example.com', '123456');
+
+    expect(result.success).toBe(false);
+    expect(service.isAuthenticated()).toBe(false);
+  });
+
+  it('signOut clears the current user', async () => {
+    const service = new AuthService();
+    await service.signUp('out@example.com', 'Out', '123456');
+    service.signOut();
+
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.getCurrentUser()).toBeNull();
+    expect(localStorage.getItem('drishya-current-user')).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- add a test folder with AuthService tests using Vitest
- configure Vitest in `vite.config.ts`
- expose `npm test` script and add Vitest as a dev dependency

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a08d172548320ab3ec5e12de87d8d