### PR TITLE
Fix trailing tag in types definition

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,4 +88,4 @@ export interface EnterpriseContact {
   teamSize: string;
   useCase: string;
   message: string;
-}</Action>
+}


### PR DESCRIPTION
## Summary
- clean up `src/types/index.ts` to remove stray closing tag

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a08ccde3883209a3fe1b9b95e7a2b