### PR TITLE
Fix video type selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
         "vite": "^5.4.2",
-        "vitest": "^1.0.0"
+        "vitest": "^1.6.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react-router-dom": "^6.20.1"
   },
   "devDependencies": {
-    "jsdom": "^26.1.0",
     "@eslint/js": "^9.9.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
@@ -27,11 +26,12 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
-    "vitest": "^1.0.0"
+    "vitest": "^1.6.1"
   }
 }

--- a/src/pages/CreateProject.tsx
+++ b/src/pages/CreateProject.tsx
@@ -314,8 +314,12 @@ export function CreateProject() {
           <VideoTypeSelector
             selectedType={formData.type}
             selectedOrientation={formData.orientation}
-            onTypeChange={(type) => updateFormData({ type })}
-            onOrientationChange={(orientation) => updateFormData({ orientation })}
+            onTypeChange={(type) =>
+              updateFormData({ type, orientation: '' })
+            }
+            onOrientationChange={(orientation) =>
+              updateFormData({ orientation })
+            }
           />
         );
       case 2:


### PR DESCRIPTION
## Summary
- reset orientation when changing video type so the selection works correctly
- update vitest to latest version for local tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a2757021c8320a6672a7bc6016307